### PR TITLE
Fixed view.php reference to QuizForm

### DIFF
--- a/view.php
+++ b/view.php
@@ -106,11 +106,11 @@ $moderator = has_capability('mod/streamline:moderate', $context);
 
     if ( $administrator && ($streamline -> quiz_xml) == null)
 	{
-		include "quiz/quizForm.php";
+		include "Quiz/quizForm.php";
 	}
     else if ( $moderator && ($streamline -> quiz_xml) == null)
 	{	
-		include "quiz/quizForm.php";
+		include "Quiz/quizForm.php";
 	}
 	else
 	{


### PR DESCRIPTION
After moving the quizForm.php from the 'quiz' folder to the 'Quiz' folder the reference was not updated in the view.php file. This change is included in this pull request.
